### PR TITLE
videojs libraries directory name is incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Select the Video.js viewer at Administration » Islandora » Solution pack confi
 
 ## Troubleshooting/Issues
 
-The Video.js directory must be installed as the directory name "video-js" in the Drupal library directory.  If you see HTTP 404 errors for "//video.js" that means Drupal has not found the "video-js" folder.
+The Video.js directory must be installed as the directory name "videojs" in the Drupal library directory.  If you see HTTP 404 errors for "//video.js" that means Drupal has not found the "videojs" folder.
 
 HTTP 404 errors for "video.js.map" is a [known issue](http://stackoverflow.com/questions/18407543/video-js-map-throwing-a-404-not-found) (the JavaScript Source Map is not included in the distribution).  You can stop the video.js client from requesting the video.js.map by removing "//@ sourceMappingURL=video.js.map" from the bottom of the video.js file.
 

--- a/islandora_videojs.module
+++ b/islandora_videojs.module
@@ -37,7 +37,7 @@ function islandora_videojs_theme($existing, $type, $theme, $path) {
 function islandora_videojs_preprocess_islandora_videojs(array &$variables) {
   $params = $variables['params'];
   $variables['tn'] = $params['tn'];
-  $videojs_path = libraries_get_path("video-js");
+  $videojs_path = libraries_get_path("videojs");
   drupal_add_js($videojs_path . "/video.js");
   drupal_add_css($videojs_path . '/video-js.css');
 


### PR DESCRIPTION
When you download and extract the video.js library, the directory name is videojs not video-js.
