### PR TITLE
Islandora 1734

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -1,10 +1,10 @@
 <?php
 /**
  * @file
- * Admin callbacks for Islandora OpenSeadragon
+ * Admin callbacks for Islandora Videojs
  */
 /**
- * Admin form. Descriptions taken from the deepzoom module.
+ * Admin form.
  */
 function islandora_videojs_admin($form, &$form_state) {
   // Get settings.
@@ -21,7 +21,7 @@ function islandora_videojs_admin($form, &$form_state) {
 }
 
 /**
- * Handles a submit from the admin pane.
+ * Validates the above element.
  */
 function videojs_hls_validate($element, $form, &$form_state) {
   if ($element['#checked'] === TRUE) {

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -3,6 +3,7 @@
  * @file
  * Admin callbacks for Islandora Videojs
  */
+
 /**
  * Admin form.
  */

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @file
+ * Admin callbacks for Islandora OpenSeadragon
+ */
+/**
+ * Admin form. Descriptions taken from the deepzoom module.
+ */
+function islandora_videojs_admin($form, &$form_state) {
+  // Get settings.
+  $form = array();
+  $form['hls_library'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Videojs-contrib-hls library'),
+    '#description' => t('Include the videojs-contrib-hls library js, videojs.contrib-hls.js?'),
+    '#default_value' => variable_get('hls_library', FALSE),
+    '#element_validate' => array('videojs_hls_validate'),
+  );
+
+  return system_settings_form($form);
+}
+
+/**
+ * Handles a submit from the admin pane.
+ */
+function videojs_hls_validate($element, $form, &$form_state) {
+  if ($element['#checked'] === TRUE) {
+    $videojs_path = libraries_get_path("video-js");
+    $videojshls = $videojs_path . "/videojs-contrib-hls.js";
+    if (!file_exists($videojshls)) {
+      form_error($element, t('The videojs-contrib-hls.js file can not be found. It can be found <a href = "https://github.com/videojs/videojs-contrib-hls/releases/tag/v3.0.2">here </a>. Place the videojs-contrib-hls.js file in /sites/all/libraries/video-js.'));
+      $form_state['hls_library']['#checked'] = FALSE;
+    }
+  }
+}

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -10,7 +10,7 @@
 function islandora_videojs_admin($form, &$form_state) {
   // Get settings.
   $form = array();
-  $form['hls_library'] = array(
+  $form['islandora_videojs_hls_library'] = array(
     '#type' => 'checkbox',
     '#title' => t('Videojs-contrib-hls library'),
     '#description' => t('Include the videojs-contrib-hls library js, videojs.contrib-hls.js?'),

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -14,8 +14,8 @@ function islandora_videojs_admin($form, &$form_state) {
     '#type' => 'checkbox',
     '#title' => t('Videojs-contrib-hls library'),
     '#description' => t('Include the videojs-contrib-hls library js, videojs.contrib-hls.js?'),
-    '#default_value' => variable_get('hls_library', FALSE),
-    '#element_validate' => array('videojs_hls_validate'),
+    '#default_value' => variable_get('islandora_videojs_hls_library', FALSE),
+    '#element_validate' => array('islandora_videojs_admin_islandora_videojs_hls_library_validate'),
   );
 
   return system_settings_form($form);
@@ -24,13 +24,13 @@ function islandora_videojs_admin($form, &$form_state) {
 /**
  * Validates the above element.
  */
-function videojs_hls_validate($element, $form, &$form_state) {
+function islandora_videojs_admin_islandora_videojs_hls_library_validate($element, &$form_state, $form) {
   if ($element['#checked'] === TRUE) {
     $videojs_path = libraries_get_path("video-js");
     $videojshls = $videojs_path . "/videojs-contrib-hls.js";
     if (!file_exists($videojshls)) {
       form_error($element, t('The videojs-contrib-hls.js file can not be found. It can be found <a href = "https://github.com/videojs/videojs-contrib-hls/releases/tag/v3.0.2">here </a>. Place the videojs-contrib-hls.js file in /sites/all/libraries/video-js.'));
-      $form_state['hls_library']['#checked'] = FALSE;
+      form_set_value($element, $form['islandora_videojs_hls_library']['#checked'] = FALSE, $form_state);
     }
   }
 }

--- a/islandora_videojs.drush.inc
+++ b/islandora_videojs.drush.inc
@@ -78,7 +78,7 @@ function drush_islandora_videojs_plugin() {
     }
 
     // Decompress the zip archive.
-    drush_tarball_extract($filename);
+    drush_tarball_extract($filename, 'video-js');
 
     // Change the directory name to "video-js" if needed.
     if ($dirname != 'video-js') {

--- a/islandora_videojs.drush.inc
+++ b/islandora_videojs.drush.inc
@@ -8,7 +8,7 @@
 /**
  * The Video.js plugin URI.
  */
-define('VIDEOJS_DOWNLOAD_URI', 'https://github.com/videojs/video.js/releases/download/v4.12.15/video-js-4.12.15.zip');
+define('VIDEOJS_DOWNLOAD_URI', 'https://github.com/videojs/video.js/releases/download/v5.10.2/video-js-5.10.2.zip');
 /**
  * The initial Video.js directory
  */

--- a/islandora_videojs.module
+++ b/islandora_videojs.module
@@ -15,6 +15,24 @@ function islandora_videojs_islandora_viewer_info() {
       'description' => t('video.js for video.'),
       'callback' => 'islandora_videojs_callback',
       'mimetype' => array('audio/mpeg', 'video/mp4'),
+      'configuration' => 'admin/islandora/islandora_viewers/videojs',
+    ),
+  );
+}
+
+/**
+ * Implements hook_menu().
+ */
+function islandora_videojs_menu() {
+  return array(
+    'admin/islandora/islandora_viewers/videojs' => array(
+      'title' => 'Video.js',
+      'description' => 'Configure the Video.js viewer.',
+      'page callback' => 'drupal_get_form',
+      'access arguments' => array('administer site configuration'),
+      'page arguments' => array('islandora_videojs_admin'),
+      'file' => 'includes/admin.form.inc',
+      'type' => MENU_NORMAL_ITEM,
     ),
   );
 }
@@ -40,7 +58,9 @@ function islandora_videojs_preprocess_islandora_videojs(array &$variables) {
   $videojs_path = libraries_get_path("video-js");
   drupal_add_js($videojs_path . "/video.js");
   drupal_add_css($videojs_path . '/video-js.css');
-
+  if (variable_get('hls_library') === 1) {
+    drupal_add_js($videojs_path . "/videojs-contrib-hls.js");
+  }
   if (isset($params['sources']) && is_array($params['sources'])) {
     $variables['sources'] = $params['sources'];
   }

--- a/islandora_videojs.module
+++ b/islandora_videojs.module
@@ -58,7 +58,7 @@ function islandora_videojs_preprocess_islandora_videojs(array &$variables) {
   $videojs_path = libraries_get_path("video-js");
   drupal_add_js($videojs_path . "/video.js");
   drupal_add_css($videojs_path . '/video-js.css');
-  if (variable_get('islandora_videojs_hls_library', 'FALSE') === FALSE) {
+  if (variable_get('islandora_videojs_hls_library', FALSE)) {
     drupal_add_js($videojs_path . "/videojs-contrib-hls.js");
   }
   if (isset($params['sources']) && is_array($params['sources'])) {

--- a/islandora_videojs.module
+++ b/islandora_videojs.module
@@ -58,7 +58,7 @@ function islandora_videojs_preprocess_islandora_videojs(array &$variables) {
   $videojs_path = libraries_get_path("video-js");
   drupal_add_js($videojs_path . "/video.js");
   drupal_add_css($videojs_path . '/video-js.css');
-  if (variable_get('hls_library') === 1) {
+  if (variable_get('islandora_videojs_hls_library', 'FALSE') === FALSE) {
     drupal_add_js($videojs_path . "/videojs-contrib-hls.js");
   }
   if (isset($params['sources']) && is_array($params['sources'])) {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1734
- Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)
  https://github.com/videojs/videojs-contrib-hls
  https://github.com/rosiel/islandora_solution_pack_streaming_media
# What does this Pull Request do?

Adds an admin form option to include and check for the HLS library for Video.js. 
# What's new?

Added an admin form with a checkbox to include the videojs-contrib-hls library and checks to see if it has been included. If it is not there will be an error directing the user to where to find the file. Once check and in place the js file will be added and HLS videos will work. Adds functionality for the streaming media solution pack. Updated the VIDEOJS_DOWNLOAD_URI version to 5.10.2 to be compatible with videojs-contrib-hls. Tested the player with the new version and the drush command. 
# How should this be tested?

Ingest a HLS video (will probably need the streaming media solution pack) and test to see that the video is playable with adding the HLS library and using the video.js player. Also confirm that a normal video can still use the video.js player with this addition. 
# Additional Notes:
# Interested parties

@nhart 
