### PR TITLE
mpeg-dash module

### DIFF
--- a/modules/islandora_videojs_dash/README.md
+++ b/modules/islandora_videojs_dash/README.md
@@ -1,0 +1,39 @@
+# Islandora Video.js MPEG-Dash support
+
+## Introduction
+
+Adds MPEG-Dash support to the islandora_videojs module via the videojs-contrib-dash.js plugin.
+
+## Requirements
+
+* [Islandora Video.js](https://github.com/islandora/islandora_videojs)
+* [Video.js](https://github.com/videojs/video.js/releases/download/v5.10.2/video-js-5.10.2.zip)
+* [Libraries](https://www.drupal.org/project/libraries)
+* [videojs-contrib-dash](https://github.com/videojs/videojs-contrib-dash/releases) will also need to be installed as a library, which also requires `dash.all.min.js`; no specific version is targeted, though this module was built against `dash.js` *2.6.2* and `videojs-contrib-dash` *2.9.2*
+
+## Installation
+
+Before enabling the module, the [dash.all.min.js](http://reference.dashif.org/dash.js/nightly/dist/dash.all.min.js) and [videojs-contrib-dash.min.js](https://github.com/videojs/videojs-contrib-dash/releases) plugins should be placed in a folder called `videojs-contrib-dash` in your site's libraries folder.
+
+After that, enable the module as usual; see [this](https://drupal.org/documentation/install/modules-themes/modules-7) for further information.
+
+## Troubleshooting/Issues
+
+Having problems or solved a problem? Check out the Islandora google groups for a solution.
+
+* [Islandora Group](https://groups.google.com/forum/?hl=en&fromgroups#!forum/islandora)
+* [Islandora Dev Group](https://groups.google.com/forum/?hl=en&fromgroups#!forum/islandora-dev)
+
+## Maintainers/Sponsors
+
+Current maintainers:
+
+* [Nelson Hart](https://github.com/nhart)
+
+## Development
+
+If you would like to contribute to this module, please check out [CONTRIBUTING.md](CONTRIBUTING.md). In addition, we have helpful [Documentation for Developers](https://github.com/Islandora/islandora/wiki#wiki-documentation-for-developers) info, as well as our [Developers](http://islandora.ca/developers) section on the [Islandora.ca](http://islandora.ca) site.
+
+## License
+
+[GPLv3](http://www.gnu.org/licenses/gpl-3.0.txt)

--- a/modules/islandora_videojs_dash/README.md
+++ b/modules/islandora_videojs_dash/README.md
@@ -7,7 +7,6 @@ Adds MPEG-Dash support to the islandora_videojs module via the videojs-contrib-d
 ## Requirements
 
 * [Islandora Video.js](https://github.com/islandora/islandora_videojs)
-* [Video.js](https://github.com/videojs/video.js/releases/download/v5.10.2/video-js-5.10.2.zip)
 * [Libraries](https://www.drupal.org/project/libraries)
 * [videojs-contrib-dash](https://github.com/videojs/videojs-contrib-dash/releases) will also need to be installed as a library, which also requires `dash.all.min.js`; no specific version is targeted, though this module was built against `dash.js` *2.6.2* and `videojs-contrib-dash` *2.9.2*
 

--- a/modules/islandora_videojs_dash/islandora_videojs_dash.info
+++ b/modules/islandora_videojs_dash/islandora_videojs_dash.info
@@ -1,0 +1,6 @@
+name = Islandora Video.js MPEG-Dash Support
+description = Adds MPEG-Dash video support to the video.js viewer
+core = 7.x
+version = 7.x-dev
+dependencies[] = islandora_videojs
+dependencies[] = libraries

--- a/modules/islandora_videojs_dash/islandora_videojs_dash.install
+++ b/modules/islandora_videojs_dash/islandora_videojs_dash.install
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @file
+ * Installation hooks.
+ */
+
+/**
+ * Implements hook_requirements().
+ */
+function islandora_videojs_dash_requirements() {
+  $t = get_t();
+  $requirements = array();
+  $dash_lib = libraries_get_path('videojs-contrib-dash');
+  $requirements['videojs_contrib_dash_library'] = array(
+    'title' => $t('videojs-contrib-dash Library'),
+    'value' => $dash_lib ? $dash_lib : $t('Missing'),
+    'severity' => $dash_lib ? REQUIREMENT_OK : REQUIREMENT_WARNING,
+  );
+  if ($dash_lib) {
+    $min_exists = file_exists($dash_lib . '/videojs-contrib-hls.min.js');
+    $requirements['videojs-contrib-dash.min.js'] = array(
+      'title' => $t('videojs-contrib-dash.min.js File'),
+      'severity' => $min_exists ? REQUIREMENT_OK : REQUIREMENT_WARNING,
+    );
+    $dash_exists = file_exists($dash_lib . '/dash.all.min.js');
+    $requirements['dash.all.min.js'] = array(
+      'title' => $t('dash.all.min.js File'),
+      'severity' => $dash_exists ? REQUIREMENT_OK : REQUIREMENT_WARNING,
+    );
+  }
+  return $requirements;
+}

--- a/modules/islandora_videojs_dash/islandora_videojs_dash.module
+++ b/modules/islandora_videojs_dash/islandora_videojs_dash.module
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * Hook implementations.
+ */
+
+/**
+ * Implements hook_template_preprocess_islandora_videojs().
+ */
+function islandora_videojs_dash_template_preprocess_islandora_videojs(array &$variables) {
+  $path = libraries_get_path('videojs-contrib-dash');
+  drupal_add_js($path . '/dash.all.min.js');
+  drupal_add_js($path . '/videojs-dash.min.js');
+}


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2083

# What does this Pull Request do?

Adds a submodule providing videojs-contrib-dash support.

# What's new?
`application/dash+xml` streams are supported by the video.js player with the enabling of a submodule and libraries.

# How should this be tested?

Might be a little tough without writing some code, but the idea is that the video.js player should work with application/dash+xml playlist streams.

# Interested parties
@nhart currently maintains, so other @Islandora/7-x-1-x-committers will have to be roped in on this.
