### PR TITLE
Responsive player option added

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,16 @@ Install as usual, see [this](https://drupal.org/documentation/install/modules-th
 Select the Video.js viewer as the default viewer for a solution pack that uses audio or video datastreams. The
  Audio Solution Pack and the Video Solution Pack are known to work with Video.js.
 
+Two additional options available are:
+
+* "Center play button" to put the play button in the center of the player, rather than the top left corner.
+
+* "Responsive player" to make the videojs player responsive but requires you use a responsive theme.
+
  For example, at Administration » Islandora » Solution pack configuration » Video Solution Pack (admin/islandora/solution_pack_config/video).
 
 [![Configuration](https://camo.githubusercontent.com/1c8251f9d0a2062abdb1433e18da6a9838a36264/687474703a2f2f692e696d6775722e636f6d2f4e684d4a5932752e706e67)](https://camo.githubusercontent.com/1c8251f9d0a2062abdb1433e18da6a9838a36264/687474703a2f2f692e696d6775722e636f6d2f4e684d4a5932752e706e67)
+
 
 
 ## Notes

--- a/css/videojs_responsive.css
+++ b/css/videojs_responsive.css
@@ -1,0 +1,6 @@
+/* video-js responsiveness, will be applied to parent div coming from the video solution pack */
+.islandora-video-content {
+width: 100%;
+max-width: 640px;
+margin: 0 auto;
+}

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -17,6 +17,18 @@ function islandora_videojs_admin($form, &$form_state) {
     '#default_value' => variable_get('islandora_videojs_hls_library', FALSE),
     '#element_validate' => array('islandora_videojs_admin_islandora_videojs_hls_library_validate'),
   );
+  $form['islandora_videojs_center_play_button'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Center play button'),
+    '#description' => t('Put the play button in the center of the player, rather than the top left corner'),
+    '#default_value' => variable_get('islandora_videojs_center_play_button', FALSE),
+  );
+  $form['islandora_videojs_responsive'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Responsive player'),
+    '#description' => t('Make the videojs player responsive (requires a responsive theme)'),
+    '#default_value' => variable_get('islandora_videojs_responsive', FALSE),
+  );
 
   return system_settings_form($form);
 }

--- a/islandora_videojs.install
+++ b/islandora_videojs.install
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @file
+ * Uninstall hook for this module.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function islandora_videojs_uninstall() {
+  $variables = array(
+    'islandora_videojs_hls_library',
+    'islandora_videojs_center_play_button',
+    'islandora_videojs_responsive',
+  );
+  array_walk($variables, 'variable_del');
+}

--- a/islandora_videojs.module
+++ b/islandora_videojs.module
@@ -70,8 +70,8 @@ function template_preprocess_islandora_videojs(array &$variables) {
   elseif (isset($params['url']) && isset($params['mime'])) {
     $variables['sources'][] = array('url' => $params['url'], 'mime' => $params['mime']);
   }
-  $variables['center_play_button'] = (variable_get('islandora_videojs_center_play_button');
-  $variables['responsive'] = (variable_get('islandora_videojs_responsive');
+  $variables['center_play_button'] = (variable_get('islandora_videojs_center_play_button'));
+  $variables['responsive'] = (variable_get('islandora_videojs_responsive'));
   if (variable_get('islandora_videojs_responsive', TRUE)) {
     drupal_add_css(drupal_get_path('module', 'islandora_videojs') . '/css/videojs_responsive.css', array('group' => CSS_DEFAULT, 'every_page' => FALSE));
   }

--- a/islandora_videojs.module
+++ b/islandora_videojs.module
@@ -70,6 +70,11 @@ function template_preprocess_islandora_videojs(array &$variables) {
   elseif (isset($params['url']) && isset($params['mime'])) {
     $variables['sources'][] = array('url' => $params['url'], 'mime' => $params['mime']);
   }
+  $variables['center_play_button'] = (variable_get('islandora_videojs_center_play_button');
+  $variables['responsive'] = (variable_get('islandora_videojs_responsive');
+  if (variable_get('islandora_videojs_responsive', TRUE)) {
+    drupal_add_css(drupal_get_path('module', 'islandora_videojs') . '/css/videojs_responsive.css', array('group' => CSS_DEFAULT, 'every_page' => FALSE));
+  }
 }
 
 /**

--- a/islandora_videojs.module
+++ b/islandora_videojs.module
@@ -70,8 +70,8 @@ function template_preprocess_islandora_videojs(array &$variables) {
   elseif (isset($params['url']) && isset($params['mime'])) {
     $variables['sources'][] = array('url' => $params['url'], 'mime' => $params['mime']);
   }
-  $variables['center_play_button'] = (bool) variable_get('islandora_videojs_center_play_button');
-  $variables['responsive'] = (bool) variable_get('islandora_videojs_responsive');
+  $variables['center_play_button'] = variable_get('islandora_videojs_center_play_button', FALSE);
+  $variables['responsive'] = variable_get('islandora_videojs_responsive', FALSE);
   if (variable_get('islandora_videojs_responsive', TRUE)) {
     drupal_add_css(drupal_get_path('module', 'islandora_videojs') . '/css/videojs_responsive.css', array('group' => CSS_DEFAULT, 'every_page' => FALSE));
   }

--- a/islandora_videojs.module
+++ b/islandora_videojs.module
@@ -70,8 +70,8 @@ function template_preprocess_islandora_videojs(array &$variables) {
   elseif (isset($params['url']) && isset($params['mime'])) {
     $variables['sources'][] = array('url' => $params['url'], 'mime' => $params['mime']);
   }
-  $variables['center_play_button'] = (variable_get('islandora_videojs_center_play_button'));
-  $variables['responsive'] = (variable_get('islandora_videojs_responsive'));
+  $variables['center_play_button'] = (bool) variable_get('islandora_videojs_center_play_button');
+  $variables['responsive'] = (bool) variable_get('islandora_videojs_responsive');
   if (variable_get('islandora_videojs_responsive', TRUE)) {
     drupal_add_css(drupal_get_path('module', 'islandora_videojs') . '/css/videojs_responsive.css', array('group' => CSS_DEFAULT, 'every_page' => FALSE));
   }

--- a/theme/islandora-videojs.tpl.php
+++ b/theme/islandora-videojs.tpl.php
@@ -6,7 +6,7 @@
   <?php if (isset($tn)): ?>
     poster="<?php print $tn; ?>"
   <?php endif; ?>
-  <?php if ($responsive != 0): ?>
+  <?php if ($responsive): ?>
     data-setup='{"fluid": true}'
   <?php else: ?>
     data-setup="{}"

--- a/theme/islandora-videojs.tpl.php
+++ b/theme/islandora-videojs.tpl.php
@@ -1,15 +1,23 @@
-<video id="islandora_videojs" class="video-js vjs-default-skin" controls
- preload="auto" width="640" height="264" 
+<video id="islandora_videojs" <?php if (empty($responsive)): ?>width="640" height="360"<?php endif; ?>
+  <?php if (empty($center_play_button)): ?>class="video-js vjs-default-skin"
+  <?php else: ?>class="video-js vjs-default-skin vjs-big-play-centered" <?php endif; ?>
+    controls
+  preload="auto"
   <?php if (isset($tn)): ?>
     poster="<?php print $tn; ?>"
   <?php endif; ?>
- data-setup="{}">
+  <?php if ($responsive != 0): ?>
+    data-setup='{"fluid": true}'
+  <?php else: ?>
+    data-setup="{}"
+  <?php endif; ?>
+  >
   <?php foreach ($sources as $source): ?>
     <source src="<?php print $source['url']; ?>" type='<?php print $source['mime']; ?>'>
   <?php endforeach; ?>
 </video>
 <?php if (empty($sources)): ?>
-<div id="video-js-warning">
-No video sources available.
-</div>
+  <div id="video-js-warning">
+    No video sources available.
+  </div>
 <?php endif; ?>

--- a/theme/islandora-videojs.tpl.php
+++ b/theme/islandora-videojs.tpl.php
@@ -1,5 +1,5 @@
-<video id="islandora_videojs" <?php if (empty($responsive)): ?>width="640" height="360"<?php endif; ?>
-  <?php if (empty($center_play_button)): ?>class="video-js vjs-default-skin"
+<video id="islandora_videojs" <?php if (!$responsive): ?>width="640" height="360"<?php endif; ?>
+  <?php if (!$center_play_button): ?>class="video-js vjs-default-skin"
   <?php else: ?>class="video-js vjs-default-skin vjs-big-play-centered" <?php endif; ?>
     controls
   preload="auto"


### PR DESCRIPTION
Added an option to make the videojs player responsive

**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1979

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)
https://groups.google.com/d/topic/islandora/pNazgPvYup8/discussion

# What does this Pull Request do?

Adds an option to make the video.js player responsive, as well as an option to put the play button in the center of the player (by adding a css class to the video object).

# What's new?
See above. Adds two config options and adds the relevant bits to the module and template. Adds a css file in case the responsive option is selected, which contains some necessary css changes for the parent div that comes from the video solution pack.

# How should this be tested?

* Check whether the behaviour of the player is still the same as before when the added config options are disabled (default)
* Enable a responsive theme, .e.g. bootstrap
* Enable the "Responsive player" config option and check whether the player scales as intended
* Enable the "Center play button" option and see whether the play button is in the center of the player rather than in the top left corner. Should work in responsive and non-responsive mode.

# Additional Notes:
* The player automatically takes the aspect ratio of the loaded video, which I personally quite like. This could also be done for the non-responsive mode by leaving out the specified height of the video object.
* Readme will need to be slightly updated to mention the added config options
* I'm not an experienced Drupal developer, so I'm not sure whether I did everything in the most suitable way

# Interested parties
@Islandora/7-x-1-x-committers