### PR TITLE
Add subtitle/transcript capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,14 @@ For example, at **Administration » Islandora » Solution pack configuration » 
 ![Solution Pack Configuration](https://user-images.githubusercontent.com/2738244/40234143-b0c31ea6-5a73-11e8-9e3b-8133917d496c.png)
 
 Configure Video.js at **Administration » Islandora » Islandora Viewers » Video.js** (_admin/islandora/islandora_viewers/videojs_). 
-Three options are available:
+Four options are available:
 
 * "Videojs-contrib-hls library" to enable HTTP Live Streaming (a streaming format native to mobile phones).
 * "Center play button" to put the play button in the center of the player, rather than the top left corner.
 * "Responsive player" to make the Video.js player responsive but requires you use a responsive theme.
+* "Transcript/Subtitle DSID" sets the datastream ID containing a WebVTT transcript.
+
+To use transcripts, on the object in question, add a custom datastream using the configured DSID (default TRANSCRIPT) and upload a WebVTT file.
 
 ![Configuration](https://user-images.githubusercontent.com/1943338/32968854-2575fc40-cbb9-11e7-9e85-66fec561a24c.png)
 

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -33,7 +33,7 @@ function islandora_videojs_admin($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Transcript/Subtitle DSID'),
     '#description' => t('Datastream ID used for transcript/subtitle datastreams.'),
-    '#default_value' => 'TRANSCRIPT',
+    '#default_value' => variable_get('islandora_videojs_transcript_dsid', 'TRANSCRIPT'),
   );
   return system_settings_form($form);
 }

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -29,7 +29,12 @@ function islandora_videojs_admin($form, &$form_state) {
     '#description' => t('Make the videojs player responsive (requires a responsive theme)'),
     '#default_value' => variable_get('islandora_videojs_responsive', FALSE),
   );
-
+  $form['islandora_videojs_transcript_dsid'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Transcript/Subtitle DSID'),
+    '#description' => t('Datastream ID used for transcript/subtitle datastreams.'),
+    '#default_value' => 'TRANSCRIPT',
+  );
   return system_settings_form($form);
 }
 

--- a/islandora_videojs.install
+++ b/islandora_videojs.install
@@ -12,6 +12,7 @@ function islandora_videojs_uninstall() {
     'islandora_videojs_hls_library',
     'islandora_videojs_center_play_button',
     'islandora_videojs_responsive',
+    'islandora_videojs_transcript_dsid',
   );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_videojs.module
+++ b/islandora_videojs.module
@@ -78,7 +78,7 @@ function template_preprocess_islandora_videojs(array &$variables) {
   $object = islandora_object_load($variables['params']['pid']);
   $variables['transcript'] = FALSE;
   $transcript_dsid = variable_get('islandora_videojs_transcript_dsid', 'TRANSCRIPT');
-  if ($object[$transcript_dsid]) {
+  if ($object[$transcript_dsid] && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object[$transcript_dsid])) {
     $variables['transcript'] = TRUE;
     $variables['transcript_path'] = url("islandora/object/{$object->id}/datastream/{$transcript_dsid}/view");
     preg_match('/Language: (.*)/', $object[$transcript_dsid]->content, $matches);

--- a/islandora_videojs.module
+++ b/islandora_videojs.module
@@ -80,7 +80,7 @@ function template_preprocess_islandora_videojs(array &$variables) {
   $transcript_dsid = variable_get('islandora_videojs_transcript_dsid', 'TRANSCRIPT');
   if ($object[$transcript_dsid]) {
     $variables['transcript'] = TRUE;
-    $variables['transcript_path'] = "/islandora/object/{$object->id}/datastream/" . $transcript_dsid . "/view";
+    $variables['transcript_path'] = url("islandora/object/{$object->id}/datastream/{$transcript_dsid}/view");
     preg_match('/Language: (.*)/', $object[$transcript_dsid]->content, $matches);
     $variables['transcript_language'] = (!empty($matches) ? $matches[1] : "English");
   }

--- a/islandora_videojs.module
+++ b/islandora_videojs.module
@@ -75,6 +75,15 @@ function template_preprocess_islandora_videojs(array &$variables) {
   if (variable_get('islandora_videojs_responsive', TRUE)) {
     drupal_add_css(drupal_get_path('module', 'islandora_videojs') . '/css/videojs_responsive.css', array('group' => CSS_DEFAULT, 'every_page' => FALSE));
   }
+  $object = islandora_object_load($variables['params']['pid']);
+  $variables['transcript'] = FALSE;
+  $transcript_dsid = variable_get('islandora_videojs_transcript_dsid', 'TRANSCRIPT');
+  if ($object[$transcript_dsid]) {
+    $variables['transcript'] = TRUE;
+    $variables['transcript_path'] = "/islandora/object/{$object->id}/datastream/" . $transcript_dsid . "/view";
+    preg_match('/Language: (.*)/', $object[$transcript_dsid]->content, $matches);
+    $variables['transcript_language'] = (!empty($matches) ? $matches[1] : "English");
+  }
 }
 
 /**

--- a/islandora_videojs.module
+++ b/islandora_videojs.module
@@ -82,7 +82,7 @@ function template_preprocess_islandora_videojs(array &$variables) {
     $variables['transcript'] = TRUE;
     $variables['transcript_path'] = url("islandora/object/{$object->id}/datastream/{$transcript_dsid}/view");
     preg_match('/Language: (.*)/', $object[$transcript_dsid]->content, $matches);
-    $variables['transcript_language'] = (!empty($matches) ? $matches[1] : "English");
+    $variables['transcript_language'] = (!empty($matches) ? check_plain($matches[1]) : "English");
   }
 }
 

--- a/theme/islandora-videojs.tpl.php
+++ b/theme/islandora-videojs.tpl.php
@@ -15,6 +15,9 @@
   <?php foreach ($sources as $source): ?>
     <source src="<?php print $source['url']; ?>" type='<?php print $source['mime']; ?>'>
   <?php endforeach; ?>
+  <?php if ($transcript): ?>
+    <track kind="captions" src="<?php print $transcript_path; ?>" label="<?php print $transcript_language; ?>" default>
+  <?php endif; ?>
 </video>
 <?php if (empty($sources)): ?>
   <div id="video-js-warning">


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/ISLANDORA-2531

# What does this Pull Request do?

Allows Islandora Videojs to display subtitles if they exist on a given audio/video object.

# What's new?

If a datastream containing a WebVTT file exists on the object being viewed, if the DSID matches the Islandora Videojs configuration, the player will display them.

# How should this be tested?

* Check out this branch
* Add a new datastream to a video/audio object with the dsid TRANSCRIPT
* Upload a WebVTT file (doesn't have to match the actual video)
* View the object; subtitles should display.

Sample WebVTT file (save as `file.vtt`):

```
WEBVTT

00:00:00.500 --> 00:00:02.000
Here is some text

00:00:02.500 --> 00:00:04.300
and here is a bit more text.
```

# Additional Notes:
The meat of this code was originally written by @bryjbrown for use at FSU; I only adapted it to make it a general-use PR.

# Interested parties
@bryjbrown @whikloj @Islandora/7-x-1-x-committers
